### PR TITLE
chore: homebrew changes

### DIFF
--- a/homebrew/Brewfile
+++ b/homebrew/Brewfile
@@ -42,10 +42,9 @@ cask "localsend"
 
 # React-Native
 brew "rbenv"
-tap "homebrew/cask-versions"
-cask "zulu17"
+cask "zulu@17"
 brew "watchman"
-cask "zulu11" # For RN v0.68
+cask "zulu@11" # For RN v0.68
 cask "android-studio"
 cask "react-native-debugger"
 brew "scrcpy"

--- a/homebrew/setup-homebrew.sh
+++ b/homebrew/setup-homebrew.sh
@@ -6,7 +6,7 @@ install_homebrew() {
   # https://brew.sh/
   if test ! $(which brew); then
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-    (echo; echo 'eval "$(/opt/homebrew/bin/brew shellenv)"') >> /Users/tom.bury/.zprofile
+    (echo; echo 'eval "$(/opt/homebrew/bin/brew shellenv)"') >> $HOME/.zprofile
     eval "$(/opt/homebrew/bin/brew shellenv)"
   fi
   brew update


### PR DESCRIPTION
Ran a complete wipe + mac setup this weekend. Found a couple things that also would be handy for you so I'm sending them upstream :)

Proposed changes:
- Use $HOME/.zprofile for rbenv setups (targeting ~/ is a safer mutation)
- Removed the cask-versions tap, it's deprecated
- Zulu now targets versions in a more npm-like syntax, eg:
```diff
- zulu11
- zulu17
+ zulu@11
+ zulu@17
```

[Off-topic] I also now added an autorunner that runs+cleans the setup, feel free to take a look at: https://github.com/jeroenptrs/mac-setup/blob/main/autosetup.sh
